### PR TITLE
reject adr if not enabled

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -836,6 +836,10 @@ scan_mac_cmds_link_adr(
     int lastOidx;
     u1_t adrAns = MCMD_LinkADRAns_PowerACK | MCMD_LinkADRAns_DataRateACK | MCMD_LinkADRAns_ChannelACK;
 
+    if( LMIC.adrEnabled == 0 ) {
+         adrAns = 0; //NACK everything
+    }
+
     // process the contiguous slots
     for (;;) {
         lastOidx = oidx;


### PR DESCRIPTION
this is a patch against lorawan servers that do send adr mac commands even though it was originally not advertised